### PR TITLE
feat: set github environment variables in `metadata json`

### DIFF
--- a/schemas/v1.0.0/lz-management/metadata.json
+++ b/schemas/v1.0.0/lz-management/metadata.json
@@ -68,6 +68,12 @@
           "branchPolicyPatterns": {
             "$ref": "github-api.json#/$defs/branchPolicyPatterns"
           },
+          "variables": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "azure": {
             "type": "object",
             "oneOf": [


### PR DESCRIPTION
This pull request updates the schema definitions for GitHub environments and metadata, primarily to support storing environment variables in the GitHub environment configuration. The changes make it possible to define and validate environment variables directly in the schema.

**Schema enhancements for environment variables:**

* Added a new `variables` property to `metadata.json`, allowing specification of a object of key-value pairs for variables to be stored in a GitHub environment.

> [!WARNING]  
> BEFORE THIS CAN BE MERGED THE CHANGES HAVE TO BE MOVED TO THE NEW VERSION FOLDER