### PR TITLE
feat: enable resource providers in schemas

### DIFF
--- a/schemas/v1.0.0/lz-management/climprconfig.lzmanagement.json
+++ b/schemas/v1.0.0/lz-management/climprconfig.lzmanagement.json
@@ -9,7 +9,8 @@
     "rootManagementGroupId",
     "decommissionedManagementGroupId",
     "billingAccountDisplayName",
-    "gitWorkloadRepository"
+    "gitWorkloadRepository",
+    "defaultResourceProviders"
   ],
   "additionalProperties": false,
   "properties": {
@@ -142,6 +143,17 @@
         },
         "runProtection": {
           "$ref": "github-api.json#/$defs/runProtection"
+        }
+      }
+    },
+    "defaultResourceProviders": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/schemas/v1.0.0/lz-management/climprconfig.lzmanagement.json
+++ b/schemas/v1.0.0/lz-management/climprconfig.lzmanagement.json
@@ -16,7 +16,7 @@
   "properties": {
     "defaultLocation": {
       "type": "string",
-      "description": "The default location for for all deployment functions.",
+      "description": "The default location for all deployment functions.",
       "default": "westeurope"
     },
     "rootManagementGroupId": {
@@ -148,6 +148,7 @@
     },
     "defaultResourceProviders": {
       "type": "object",
+      "description": "The resource providers and features to be enabled for all landing zones.",
       "patternProperties": {
         ".*": {
           "type": "array",

--- a/schemas/v1.0.0/lz-management/metadata.json
+++ b/schemas/v1.0.0/lz-management/metadata.json
@@ -216,6 +216,17 @@
       "invoiceSectionDisplayName": {
         "type": "string",
         "description": "The name of the Invoice Section for the subscription."
+      },
+      "resourceProviders": {
+        "type": "object",
+        "patternProperties": {
+          ".*": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
     "repoSource": {


### PR DESCRIPTION
Resource providers for all landing zones would go in the `defaultResourceProviders` and individual `metadata.json` would be able to add additional providers and/or features.

> Register a resource provider only when you're ready to use it. 

https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-services-resource-providers#registration