### PR TITLE
Add support for 'latest' version of azcli and bicepVersion

### DIFF
--- a/schemas/v1.0.0/bicep-deployment/climprconfig.bicepdeployment.json
+++ b/schemas/v1.0.0/bicep-deployment/climprconfig.bicepdeployment.json
@@ -19,8 +19,29 @@
     },
     "azureCliVersion": {
       "type": "string",
-      "format": "regex",
-      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+      "description": "The Azure CLI version to use.",
+      "oneOf": [
+        {
+          "const": "latest"
+        },
+        {
+          "format": "regex",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        }
+      ]
+    },
+    "bicepVersion": {
+      "type": "string",
+      "description": "The Bicep version to use.",
+      "oneOf": [
+        {
+          "const": "latest"
+        },
+        {
+          "format": "regex",
+          "pattern": "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        }
+      ]
     }
   }
 }

--- a/schemas/v1.0.0/bicep-deployment/deploymentconfig.json
+++ b/schemas/v1.0.0/bicep-deployment/deploymentconfig.json
@@ -55,6 +55,9 @@
                 "azureCliVersion": {
                   "$ref": "#/$defs/common/azureCliVersion"
                 },
+                "bicepVersion": {
+                  "$ref": "#/$defs/common/bicepVersion"
+                },
                 "name": {
                   "$ref": "#/$defs/deployment/name"
                 },
@@ -98,6 +101,9 @@
                 "azureCliVersion": {
                   "$ref": "#/$defs/common/azureCliVersion"
                 },
+                "bicepVersion": {
+                  "$ref": "#/$defs/common/bicepVersion"
+                },
                 "name": {
                   "$ref": "#/$defs/deployment/name"
                 },
@@ -140,6 +146,9 @@
                 },
                 "azureCliVersion": {
                   "$ref": "#/$defs/common/azureCliVersion"
+                },
+                "bicepVersion": {
+                  "$ref": "#/$defs/common/bicepVersion"
                 },
                 "name": {
                   "$ref": "#/$defs/deployment/name"
@@ -186,6 +195,9 @@
                 },
                 "azureCliVersion": {
                   "$ref": "#/$defs/common/azureCliVersion"
+                },
+                "bicepVersion": {
+                  "$ref": "#/$defs/common/bicepVersion"
                 },
                 "name": {
                   "$ref": "#/$defs/deployment/name"
@@ -251,6 +263,9 @@
                 "azureCliVersion": {
                   "$ref": "#/$defs/common/azureCliVersion"
                 },
+                "bicepVersion": {
+                  "$ref": "#/$defs/common/bicepVersion"
+                },
                 "name": {
                   "$ref": "#/$defs/deploymentStack/name"
                 },
@@ -308,6 +323,9 @@
                 },
                 "azureCliVersion": {
                   "$ref": "#/$defs/common/azureCliVersion"
+                },
+                "bicepVersion": {
+                  "$ref": "#/$defs/common/bicepVersion"
                 },
                 "name": {
                   "$ref": "#/$defs/deploymentStack/name"
@@ -374,6 +392,9 @@
                 },
                 "azureCliVersion": {
                   "$ref": "#/$defs/common/azureCliVersion"
+                },
+                "bicepVersion": {
+                  "$ref": "#/$defs/common/bicepVersion"
                 },
                 "name": {
                   "$ref": "#/$defs/deploymentStack/name"
@@ -469,6 +490,19 @@
           {
             "format": "regex",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+          }
+        ]
+      },
+      "bicepVersion": {
+        "type": "string",
+        "description": "The Bicep version to use.",
+        "oneOf": [
+          {
+            "const": "latest"
+          },
+          {
+            "format": "regex",
+            "pattern": "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
           }
         ]
       }

--- a/schemas/v1.0.0/bicep-deployment/deploymentconfig.json
+++ b/schemas/v1.0.0/bicep-deployment/deploymentconfig.json
@@ -34,9 +34,7 @@
             "then": {
               "description": "The schema for Bicep deployments scoped to a Resource Group",
               "type": "object",
-              "required": [
-                "resourceGroupName"
-              ],
+              "required": ["resourceGroupName"],
               "additionalProperties": false,
               "properties": {
                 "type": {
@@ -122,9 +120,7 @@
             "then": {
               "description": "The schema for Bicep deployments scoped to a Management Group",
               "type": "object",
-              "required": [
-                "managementGroupId"
-              ],
+              "required": ["managementGroupId"],
               "additionalProperties": false,
               "properties": {
                 "type": {
@@ -170,9 +166,7 @@
             "then": {
               "description": "The schema for Bicep deployments scoped to a Tenant",
               "type": "object",
-              "required": [
-                "scope"
-              ],
+              "required": ["scope"],
               "additionalProperties": false,
               "properties": {
                 "type": {
@@ -217,9 +211,7 @@
         }
       },
       "then": {
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "oneOf": [
           {
             "$comment": "Deployment Stack - Resource Group scope",
@@ -296,11 +288,7 @@
             "then": {
               "description": "The schema for Deployment Stacks scoped to a Subscription",
               "type": "object",
-              "required": [
-                "name",
-                "actionOnUnmanage",
-                "denySettings"
-              ],
+              "required": ["name", "actionOnUnmanage", "denySettings"],
               "additionalProperties": false,
               "properties": {
                 "type": {
@@ -433,21 +421,13 @@
       "type": {
         "type": "string",
         "description": "Specifies the execution type.",
-        "enum": [
-          "deployment",
-          "deploymentStack"
-        ],
+        "enum": ["deployment", "deploymentStack"],
         "default": "deployment"
       },
       "scope": {
         "type": "string",
         "description": "Specifies the scope of the deployment or deploymentStack.",
-        "enum": [
-          "resourceGroup",
-          "subscription",
-          "managementGroup",
-          "tenant"
-        ],
+        "enum": ["resourceGroup", "subscription", "managementGroup", "tenant"],
         "default": "subscription"
       },
       "disabled": {
@@ -482,8 +462,15 @@
       "azureCliVersion": {
         "type": "string",
         "description": "The Azure CLI version to use.",
-        "format": "regex",
-        "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        "oneOf": [
+          {
+            "const": "latest"
+          },
+          {
+            "format": "regex",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+          }
+        ]
       }
     },
     "deployment": {
@@ -543,33 +530,22 @@
         "type": "object",
         "description": "Defines the behavior of resources that are not managed immediately after the stack is updated.",
         "additionalProperties": false,
-        "required": [
-          "resources"
-        ],
+        "required": ["resources"],
         "properties": {
           "resources": {
             "type": "string",
             "description": "Specifies the action that should be taken on the resource when the deployment stack is deleted. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
-            "enum": [
-              "delete",
-              "detach"
-            ]
+            "enum": ["delete", "detach"]
           },
           "resourceGroups": {
             "type": "string",
             "description": "Specifies the action that should be taken on the resource when the deployment stack is deleted. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
-            "enum": [
-              "delete",
-              "detach"
-            ]
+            "enum": ["delete", "detach"]
           },
           "managementGroups": {
             "type": "string",
             "description": "Specifies the action that should be taken on the resource when the deployment stack is deleted. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
-            "enum": [
-              "delete",
-              "detach"
-            ]
+            "enum": ["delete", "detach"]
           }
         }
       },


### PR DESCRIPTION
This pull request updates the Bicep deployment JSON schemas to add support for specifying the Bicep CLI version, along with improvements for consistency and maintainability. The changes introduce a new `bicepVersion` property, allow both `latest` and specific version formats for CLI versions, and simplify schema formatting.

### Support for Bicep and Azure CLI version specification

* Added a new `bicepVersion` property to both `climprconfig.bicepdeployment.json` and `deploymentconfig.json`, allowing users to specify either `"latest"` or an explicit version string using a regex pattern. This matches the existing approach for `azureCliVersion`. [[1]](diffhunk://#diff-40bf48e9d72ac0ce227b1f33fc9a07783e9afcd4f9919e757e3dfd80602e9bd2R22-R45) [[2]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR58-R60) [[3]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR104-R106) [[4]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR150-R152) [[5]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR199-R201) [[6]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR266-R268) [[7]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR327-R329) [[8]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR396-R398) [[9]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffR486-R508)

### Schema formatting and consistency improvements

* Simplified array formatting for `required` and `enum` fields throughout `deploymentconfig.json` to use single-line syntax, improving readability and consistency. [[1]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffL37-R37) [[2]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffL125-R129) [[3]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffL173-R178) [[4]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffL220-R226) [[5]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffL299-R306) [[6]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffL436-R451) [[7]](diffhunk://#diff-cc86882ffcf38440d3057dbcda3982c398ad5ae548b904308f4e6948d17419ffL546-R582)

These changes make it easier to configure deployment environments and maintain the schema files.